### PR TITLE
correct table name references to prevent server disconnection

### DIFF
--- a/modules/filters.R
+++ b/modules/filters.R
@@ -12,12 +12,12 @@ filter_data_server <- function(input, data, session) {
     if (!is.null(input$species) && length(input$species) > 0) {
       data_filtered <- data_filtered[data_filtered$species_common_name %in% input$species, ]
     }
-    
+
     # Filter: geography
     if (!is.null(input$geography) && length(input$geography) > 0) {
       data_filtered <- data_filtered[data_filtered$geography %in% input$geography, ]
     }
-    
+
     # Filter: life stage
     if (!is.null(input$life_stage) && length(input$life_stage) > 0) {
       data_filtered <- data_filtered[
@@ -26,17 +26,17 @@ filter_data_server <- function(input, data, session) {
         })),
       ]
     }
-    
+
     # Filter: activity
     if (!is.null(input$activity) && length(input$activity) > 0) {
       data_filtered <- data_filtered[data_filtered$activity %in% input$activity, ]
     }
-    
+
     # Filter: genus latin
     if (!is.null(input$genus_latin) && length(input$genus_latin) > 0) {
       data_filtered <- data_filtered[data_filtered$genus_latin %in% input$genus_latin, ]
     }
-    
+
     # Filter: species latin
     if (!is.null(input$species_latin) && length(input$species_latin) > 0) {
       data_filtered <- data_filtered[data_filtered$species_latin %in% input$species_latin, ]
@@ -84,3 +84,4 @@ filter_data_server <- function(input, data, session) {
 
   return(filtered_data)
 }
+# nolint end

--- a/modules/manage_categories.R
+++ b/modules/manage_categories.R
@@ -7,24 +7,24 @@ library(shinyWidgets)
 # UI function for Manage Categories module
 manageCategoriesUI <- function(id) {
   ns <- NS(id)
-  
+
   cat_choices <- list(
-    "Stressor Name"        = "stressor_names",
-    "Stressor Metric"      = "stressor_metrics",
-    "Species Common Name"  = "species_common_names",
-    "Geography"            = "geographies",
-    "Life Stage"           = "life_stages",
-    "Activity"             = "activities",
-    "Genus Latin"          = "genus_latins",
-    "Species Latin"        = "species_latins",
-    "Stressor Category"      = "broad_stressor_names",
+    "Stressor Name"         = "stressor_names",
+    "Stressor Metric"       = "stressor_metrics",
+    "Species Common Name"   = "species_common_names",
+    "Geography"             = "geographies",
+    "Life Stage"            = "life_stages",
+    "Activity"              = "activities",
+    "Genus Latin"           = "genus_latins",
+    "Species Latin"         = "species_latins",
+    "Stressor Category"     = "broad_stressor_names",
     "Research Article Type" = "research_article_types",
-    "Country"                = "location_countries",
-    "State/Province"         = "location_state_provinces",
-    "Watershed Lab"          = "location_watershed_labs",
-    "River/Creek"            = "location_river_creeks"
+    "Country"               = "location_countries",
+    "State/Province"        = "location_states_provinces",
+    "Watershed/Lab"         = "location_watersheds_labs",
+    "River/Creek"           = "location_rivers_creeks"
   )
-  
+
   tagList(
     # — Category panels
     fluidRow(
@@ -48,7 +48,7 @@ manageCategoriesUI <- function(id) {
       )
     ),
     tags$hr(),
-    
+
     # — Article Deletion Panel —
     fluidRow(
       column(12,
@@ -87,7 +87,7 @@ manageCategoriesServer <- function(id, db, onUpdate = NULL) {
     ns <- session$ns
 
     #
-    # 1) —— ADD CATEGORY —— 
+    # 1) —— ADD CATEGORY ——
     #
     observeEvent(input$add_cat, {
       req(input$new_cat_name)
@@ -107,7 +107,7 @@ manageCategoriesServer <- function(id, db, onUpdate = NULL) {
     })
 
     #
-    # 2) —— DELETE CATEGORY —— 
+    # 2) —— DELETE CATEGORY ——
     #
     observeEvent(input$del_cat_type, {
       names <- dbGetQuery(db,
@@ -136,7 +136,7 @@ manageCategoriesServer <- function(id, db, onUpdate = NULL) {
     })
 
     #
-    # 3) —— SEARCH ARTICLES —— 
+    # 3) —— SEARCH ARTICLES ——
     #
     observeEvent(input$search_article, {
       query  <- "SELECT main_id, title FROM stressor_responses WHERE 1=1"
@@ -163,7 +163,7 @@ manageCategoriesServer <- function(id, db, onUpdate = NULL) {
     })
 
     #
-    # 4) —— DELETE ARTICLE —— 
+    # 4) —— DELETE ARTICLE ——
     #
     observeEvent(input$del_article_btn, {
       req(input$del_article_sel)
@@ -194,4 +194,4 @@ manageCategoriesServer <- function(id, db, onUpdate = NULL) {
   })
 
 }
-# nolint end 
+# nolint end


### PR DESCRIPTION
fixes: #2 

### Overview

Found and fixed erroneous references to 3 location tables. This fix prevents the application from disconnecting from the server when a user tries to select the category type to delete.

### Tasks Completed

- Within `modules/manage_categories.R`,
  - changed `location_state_provinces` to `location_states_provinces`
  - changed `location_watershed_labs` to `location_watersheds_labs`
  - changed `location_river_creeks` to `location_rivers_creeks`
  - added a `/` between Watershed and Lab in the category choice name
  - Prettier formatting
- Within `modules/filters.R`,
  - added `# nolint end` to bottom of file to prevent error
  - Prettier formatting