### PR TITLE
fix(issue-3): preserve filter state by moving article detail view to modal

### DIFF
--- a/modules/render_article_ui.R
+++ b/modules/render_article_ui.R
@@ -3,140 +3,137 @@
 library(shinyjs)
 library(dygraphs)
 
-render_article_ui <- function(output, session) {
-  output$article_content <- renderUI({
-    
-    tagList(
-      tags$head(
-        includeCSS("www/custom.css")
-      ),
-      useShinyjs(),  # Enabling JavaScript for toggling sections
-      
-      
-      # Back button to return to dashboard
-      tags$a(
-        href = "?",
-        tags$div(id = "customArrow", class = "arrow-container")
-      ),
-      tags$style(HTML("
-        .arrow-container {
-          width: 30px;
-          height: 30px;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          cursor: pointer;
-        }
-        
-        .arrow-container::before {
-          content: '\\2190'; /* Unicode for left arrow */
-          font-size: 35px;
-          color: #2C3E50;
-        }
-      ")),
-      
-      # ===== Article title =====
-      fluidRow(
-        column(12, align = "center",
-               tags$h3(textOutput("article_title"),
-                       style = "margin-top: 20px; margin-bottom: 10px;")
+render_article_ui <- function(main_id, data) {
+  # Find the article row
+  article <- data[data$main_id == main_id, ]
+  if (nrow(article) == 0) {
+    return(tags$p("Article not found."))
+  }
+
+  # Unique IDs for this article
+  meta_id <- paste0("metadata_section_", main_id)
+  desc_id <- paste0("description_section_", main_id)
+  cite_id <- paste0("citations_section_", main_id)
+  expand_id <- paste0("expand_all_", main_id)
+  collapse_id <- paste0("collapse_all_", main_id)
+
+  tagList(
+    # ===== Article title =====
+    fluidRow(
+      column(12,
+        align = "center",
+        tags$h3(article$title,
+          style = "margin-top: 20px; margin-bottom: 10px;"
         )
-      ),
-      
-      # ===== Expand / Collapse =====
-      fluidRow(
-        column(12, align = "center",
-               actionButton("expand_all",   "Expand All",
-                            class = "btn-sm",
-                            style = "padding: 8px 16px; margin-right: 8px;"),
-               actionButton("collapse_all", "Collapse All",
-                            class = "btn-sm",
-                            style = "padding: 8px 16px;")
-        )
-      ),
-      
-      
-      # Article Metadata Section 
-      div(style = "border: 1px solid #ddd; padding: 15px; margin-bottom: 10px; background-color: #f8f9fa; border-radius: 8px;",
-          actionLink("toggle_metadata", "Article Metadata ▼", class = "section-title"),
-          hidden(
-            div(id = "metadata_section",
-                style = "font-size:1.1em;",    
-                fluidRow(
-                  column(4, strong("Species Common Name:")),
-                  column(8, textOutput("species_name"))
-                ),
-                fluidRow(
-                  column(4, strong("Latin Name (Genus species):")),
-                  column(8, em(textOutput("genus_latin")))
-                ),
-                fluidRow(
-                  column(4, strong("Stressor Name:")),
-                  column(8, textOutput("stressor_name"))
-                ),
-                fluidRow(
-                  column(4, strong("Specific Stressor Metric:")),
-                  column(8, textOutput("specific_stressor_metric"))
-                ),
-                fluidRow(
-                  column(4, strong("Stressor Units:")),
-                  column(8, textOutput("stressor_units"))
-                ),
-                fluidRow(
-                  column(4, strong("Vital Rate (Process):")),
-                  column(8, textOutput("vital_rate"))
-                ),
-                fluidRow(
-                  column(4, strong("Life Stage:")),
-                  column(8, textOutput("life_stage"))
-                )
-            )
-          )
-      ),
-
-      # Description & Function Details 
-      div(style = "border: 1px solid #ddd; padding: 15px; margin-bottom: 10px; background-color: #ffffff; border-radius: 8px;",
-          actionLink("toggle_description", "Description & Function Details ▼", class = "section-title"),
-          hidden(div(id = "description_section",
-                     style = "font-size:1.1em;", 
-              strong("Detailed SR Function Description"), br(), textOutput("description_overview"), br(), br(),
-              strong("Function Derivation"), br(), textOutput("function_derivation")
-          ))
-      ),
-
-      # Citations Section 
-      div(style = "border: 1px solid #ddd; padding: 15px; margin-bottom: 10px; background-color: #ffffff; border-radius: 8px;",
-          actionLink("toggle_citations", "Citation(s) ▼", class = "section-title"),
-          hidden(div(id = "citations_section",  style = "font-size:1.1em;",  uiOutput("citations")))
-      ),
-
-      # Images Section 
-      div(style = "border: 1px solid #ddd; padding: 15px; margin-bottom: 10px; background-color: #ffffff; border-radius: 8px;",
-          actionLink("toggle_images", "Images ▼", class = "section-title"),
-          hidden(div(id = "images_section",  style = "font-size:1.1em;", uiOutput("article_images")))
-      ),
-
-      # CSV Data Table 
-      div(style = "border: 1px solid #ddd; padding: 15px; margin-bottom: 10px; background-color: #ffffff; border-radius: 8px;",
-          actionLink("toggle_csv", "Stressor Response Data ▼", class = "section-title"),
-          hidden(div(id = "csv_section",  style = "font-size:1.1em;", tableOutput("csv_table")))
-      ),
-
-      # Stressor Response Plot 
-      #div(style = "border: 1px solid #ddd; padding: 15px; margin-bottom: 10px; background-color: #ffffff; border-radius: 8px;",
-         # actionLink("toggle_plot", "Stressor Response Chart ▼", class = "section-title"),
-          #hidden(div(id = "plot_section",  style = "font-size:1.1em;", plotOutput("stressor_plot")))
-    #  ),
-      
-      # Interactive Plot Section using dygraphs
-      # Interactive Plot Section using Plotly
-      div(
-        style = "border: 1px solid #ddd; padding: 15px; margin-bottom: 10px; background-color: #ffffff; border-radius: 8px;",
-        actionLink("toggle_interactive_plot", "Stressor Response Chart ▼", class = "section-title"),
-        hidden(div(id = "interactive_plot_section",  style = "font-size:1.1em;", plotlyOutput("interactive_plot")))
       )
+    ),
+
+    # ===== Expand / Collapse =====
+    fluidRow(
+      column(12,
+        align = "center",
+        actionButton(expand_id, "Expand All",
+          class = "btn-sm",
+          style = "padding: 8px 16px; margin-right: 8px;"
+        ),
+        actionButton(collapse_id, "Collapse All",
+          class = "btn-sm",
+          style = "padding: 8px 16px;"
+        )
+      )
+    ),
+
+
+    # Article Metadata Section
+    div(
+      style = "border: 1px solid #ddd; padding: 15px; margin-bottom: 10px; background-color: #f8f9fa; border-radius: 8px;",
+      actionLink("toggle_metadata", "Article Metadata ▼", class = "section-title"),
+      hidden(
+        div(
+          id = "metadata_section",
+          style = "font-size:1.1em;",
+          fluidRow(
+            column(4, strong("Species Common Name:")),
+            column(8, textOutput("species_name"))
+          ),
+          fluidRow(
+            column(4, strong("Latin Name (Genus species):")),
+            column(8, em(textOutput("genus_latin")))
+          ),
+          fluidRow(
+            column(4, strong("Stressor Name:")),
+            column(8, textOutput("stressor_name"))
+          ),
+          fluidRow(
+            column(4, strong("Specific Stressor Metric:")),
+            column(8, textOutput("specific_stressor_metric"))
+          ),
+          fluidRow(
+            column(4, strong("Stressor Units:")),
+            column(8, textOutput("stressor_units"))
+          ),
+          fluidRow(
+            column(4, strong("Vital Rate (Process):")),
+            column(8, textOutput("vital_rate"))
+          ),
+          fluidRow(
+            column(4, strong("Life Stage:")),
+            column(8, textOutput("life_stage"))
+          )
+        )
+      )
+    ),
+
+    # Description & Function Details
+    div(
+      style = "border: 1px solid #ddd; padding: 15px; margin-bottom: 10px; background-color: #ffffff; border-radius: 8px;",
+      actionLink("toggle_description", "Description & Function Details ▼", class = "section-title"),
+      hidden(div(
+        id = "description_section",
+        style = "font-size:1.1em;",
+        strong("Detailed SR Function Description"), br(), textOutput("description_overview"), br(), br(),
+        strong("Function Derivation"), br(), textOutput("function_derivation")
+      ))
+    ),
+
+    # Citations Section
+    div(
+      style = "border: 1px solid #ddd; padding: 15px; margin-bottom: 10px; background-color: #ffffff; border-radius: 8px;",
+      actionLink("toggle_citations", "Citation(s) ▼", class = "section-title"),
+      hidden(div(
+        id = "citations_section",
+        style = "font-size:1.1em;",
+        uiOutput("citations")
+      ))
+    ),
+
+    # Images Section
+    div(
+      style = "border: 1px solid #ddd; padding: 15px; margin-bottom: 10px; background-color: #ffffff; border-radius: 8px;",
+      actionLink("toggle_images", "Images ▼", class = "section-title"),
+      hidden(div(id = "images_section", style = "font-size:1.1em;", uiOutput("article_images")))
+    ),
+
+    # CSV Data Table
+    div(
+      style = "border: 1px solid #ddd; padding: 15px; margin-bottom: 10px; background-color: #ffffff; border-radius: 8px;",
+      actionLink("toggle_csv", "Stressor Response Data ▼", class = "section-title"),
+      hidden(div(id = "csv_section", style = "font-size:1.1em;", tableOutput("csv_table")))
+    ),
+
+    # Stressor Response Plot
+    # div(style = "border: 1px solid #ddd; padding: 15px; margin-bottom: 10px; background-color: #ffffff; border-radius: 8px;",
+    # actionLink("toggle_plot", "Stressor Response Chart ▼", class = "section-title"),
+    # hidden(div(id = "plot_section",  style = "font-size:1.1em;", plotOutput("stressor_plot")))
+    # ),
+
+    # Interactive Plot Section using Plotly
+    div(
+      style = "border: 1px solid #ddd; padding: 15px; margin-bottom: 10px; background-color: #ffffff; border-radius: 8px;",
+      actionLink("toggle_interactive_plot", "Stressor Response Chart ▼", class = "section-title"),
+      hidden(div(id = "interactive_plot_section", style = "font-size:1.1em;", plotlyOutput("interactive_plot")))
     )
-  })
+  )
 }
 
 # nolint end

--- a/modules/render_papers.R
+++ b/modules/render_papers.R
@@ -2,16 +2,17 @@
 render_papers_server <- function(output, paginated_data, input, session) {
   output$paper_cards <- renderUI({
     data_to_display <- paginated_data()
-    
+
     format_field <- function(label, val, bold = FALSE) {
       display <- ifelse(is.na(val) || val == "NA", "", val)
-      if (display == "") return("")
+      if (display == "") {
+        return("")
+      }
       value_span <- sprintf("<span class='%s'>%s</span>", if (bold) "metadata-bold" else "metadata-light", htmltools::htmlEscape(display))
       label_span <- sprintf("<span class='metadata-label'>%s:</span> ", htmltools::htmlEscape(label))
       div_class <- "paper-meta-item"
       sprintf("<div class='%s' title='%s'>%s%s</div>", div_class, htmltools::htmlEscape(display), label_span, value_span)
     }
-
 
     if (is.null(data_to_display) || nrow(data_to_display) == 0) {
       return(tags$p(
@@ -19,67 +20,68 @@ render_papers_server <- function(output, paginated_data, input, session) {
         style = "font-size: 18px; font-weight: bold; color: red;"
       ))
     }
-    
+
     # Remove rows where all values are NA
     data_to_display <- data_to_display[rowSums(is.na(data_to_display)) != ncol(data_to_display), ]
-    
+
     tagList(
       lapply(seq_len(nrow(data_to_display)), function(i) {
         paper <- data_to_display[i, ]
-        
+
         article_url <- paste0("?main_id=", paper$main_id)
         checkbox_id <- paste0("select_article_", paper$main_id)
-        
+
         div(
           class = "hover-highlight",
           style = "padding: 8px 12px; margin: 6px auto; border-radius: 6px; width: 95%;
                 display: flex; align-items: flex-start; justify-content: flex-start;
                 border: 1px solid #ddd; background-color: #f9f9f9; min-height: 80px;",
 
-        # Checkbox
-        div(style = "margin-right: 10px; margin-top: 5px;",
+          # Checkbox
+          div(
+            style = "margin-right: 10px; margin-top: 5px;",
             checkboxInput(inputId = checkbox_id, label = NULL, value = FALSE, width = "20px")
-        ),
+          ),
 
-        # Title + Metadata block
-        div(style = "flex-grow: 1; padding-left: 10px;",
+          # Title + Metadata block
+          div(
+            style = "flex-grow: 1; padding-left: 10px;",
 
             # Title
-            tags$a(
-              href = article_url,
-              target = "_self",
-              class = "paper-card-title",
-              paste0(paper$main_id, ". ", paper$title)
+            actionButton(
+              inputId = paste0("view_article_", paper$main_id),
+              label = paste0(paper$main_id, ". ", paper$title),
+              class = "paper-card-title btn-link"
             ),
 
             # Metadata rows
-            div(class = "paper-meta-row",
+            div(
+              class = "paper-meta-row",
               HTML(format_field("Common Name", paper$species_common_name, TRUE)),
               HTML(format_field("Life Stage", paper$life_stages, TRUE)),
               HTML(format_field("Type", paper$research_article_type, TRUE)),
               HTML(format_field("Activity", paper$activity, TRUE))
             ),
-            div(class = "paper-meta-row",
+            div(
+              class = "paper-meta-row",
               HTML(format_field("Stressor", paper$stressor_name, TRUE)),
               HTML(format_field("Metric", paper$specific_stressor_metric, TRUE)),
               HTML(format_field("Broad Stressor", paper$broad_stressor_name, TRUE)),
               HTML(format_field("Genus Latin", paper$genus_latin, TRUE))
-
             ),
-            div(class = "paper-meta-row",
+            div(
+              class = "paper-meta-row",
               HTML(format_field("River/Creek", paper$location_river_creek, TRUE)),
               HTML(format_field("Watershed/Lab", paper$location_watershed_lab, TRUE)),
               HTML(format_field("State/Province", paper$location_state_province, TRUE)),
               HTML(format_field("Country", paper$location_country, TRUE))
             )
-
+          )
         )
-      )
-
       })
     )
   })
-  
+
   # Sync all checkboxes with "Select All"
   observeEvent(input$select_all, {
     ids <- paginated_data()$main_id

--- a/server.R
+++ b/server.R
@@ -2,8 +2,8 @@
 
 # Load required modules
 source("global.R")
-source("modules/about_us.R", local = TRUE)             # Restored
-source("modules/acknowledgement.R", local = TRUE)      # Restored
+source("modules/about_us.R", local = TRUE) # Restored
+source("modules/acknowledgement.R", local = TRUE) # Restored
 source("modules/filters.R", local = TRUE)
 source("modules/pagination.R", local = TRUE)
 source("modules/render_papers.R", local = TRUE)
@@ -20,42 +20,47 @@ source("modules/eda.R", local = TRUE)
 
 
 server <- function(input, output, session) {
-
-  observeEvent(input$main_navbar, {
-    if (input$main_navbar == "dashboard") {
-      updateFilterDropdowns()
-    }
-  }, ignoreInit = TRUE)
+  observeEvent(input$main_navbar,
+    {
+      if (input$main_navbar == "dashboard") {
+        updateFilterDropdowns()
+      }
+    },
+    ignoreInit = TRUE
+  )
 
   updateFilterDropdowns <- function() {
-  updatePickerInput(session, "stressor", choices = getCategoryChoices("stressor_names"))
-  updatePickerInput(session, "stressor_metric", choices = getCategoryChoices("stressor_metrics"))
-  updatePickerInput(session, "species", choices = getCategoryChoices("species_common_names"))
-  updatePickerInput(session, "geography", choices = getCategoryChoices("geographies"))
-  updatePickerInput(session, "life_stage", choices = getCategoryChoices("life_stages"))
-  updatePickerInput(session, "activity", choices = getCategoryChoices("activities"))
-  updatePickerInput(session, "genus_latin", choices = getCategoryChoices("genus_latins"))
-  updatePickerInput(session, "species_latin", choices = getCategoryChoices("species_latins"))
-  updatePickerInput(session, "research_article_type", choices = getCategoryChoices("research_article_types"))
-  updatePickerInput(session, "location_country", choices = getCategoryChoices("location_countries"))
-  updatePickerInput(session, "location_state_province", choices = getCategoryChoices("location_state_provinces"))
-  updatePickerInput(session, "location_watershed_lab", choices = getCategoryChoices("location_watershed_labs"))
-  updatePickerInput(session, "location_river_creek", choices = getCategoryChoices("location_river_creeks"))
-  updatePickerInput(session, "broad_stressor_name", choices = getCategoryChoices("broad_stressor_names"))
+    updatePickerInput(session, "stressor", choices = getCategoryChoices("stressor_names"))
+    updatePickerInput(session, "stressor_metric", choices = getCategoryChoices("stressor_metrics"))
+    updatePickerInput(session, "species", choices = getCategoryChoices("species_common_names"))
+    updatePickerInput(session, "geography", choices = getCategoryChoices("geographies"))
+    updatePickerInput(session, "life_stage", choices = getCategoryChoices("life_stages"))
+    updatePickerInput(session, "activity", choices = getCategoryChoices("activities"))
+    updatePickerInput(session, "genus_latin", choices = getCategoryChoices("genus_latins"))
+    updatePickerInput(session, "species_latin", choices = getCategoryChoices("species_latins"))
+    updatePickerInput(session, "research_article_type", choices = getCategoryChoices("research_article_types"))
+    updatePickerInput(session, "location_country", choices = getCategoryChoices("location_countries"))
+    updatePickerInput(session, "location_state_province", choices = getCategoryChoices("location_state_provinces"))
+    updatePickerInput(session, "location_watershed_lab", choices = getCategoryChoices("location_watershed_labs"))
+    updatePickerInput(session, "location_river_creek", choices = getCategoryChoices("location_river_creeks"))
+    updatePickerInput(session, "broad_stressor_name", choices = getCategoryChoices("broad_stressor_names"))
   }
 
   getCategoryChoices <- function(table_name) {
-  tryCatch({
-    dbGetQuery(db, sprintf("SELECT name FROM %s ORDER BY name", table_name))$name
-  }, error = function(e) {
-    character(0)
-  })
-}
+    tryCatch(
+      {
+        dbGetQuery(db, sprintf("SELECT name FROM %s ORDER BY name", table_name))$name
+      },
+      error = function(e) {
+        character(0)
+      }
+    )
+  }
 
 
   # Launch admin authentication
   # admin_ok <- adminAuthServer("auth", correct_pw = "secret123")
-  
+
   # output$categories_auth_ui <- renderUI({
   #   if (!admin_ok()) {
   #     adminAuthUI("auth")
@@ -72,7 +77,7 @@ server <- function(input, output, session) {
   #     manageCategoriesServer("manage_categories", db)
   #   }
   # })
-  
+
   # Global logout tracker
   admin_logged_in <- reactiveVal(FALSE)
 
@@ -93,7 +98,6 @@ server <- function(input, output, session) {
     }
   })
 
-
   observeEvent(admin_logged_in(), {
     if (admin_logged_in()) {
       manageCategoriesServer("manage_categories", db)
@@ -105,7 +109,6 @@ server <- function(input, output, session) {
     admin_logged_in(FALSE)
   })
 
-
   # Connect to database
   db <- tryCatch(
     dbConnect(SQLite(), "data/stressor_responses.sqlite"),
@@ -113,19 +116,19 @@ server <- function(input, output, session) {
       stop("Error: Unable to connect to the database.")
     }
   )
-  
+
   if (!"stressor_responses" %in% dbListTables(db)) {
     stop("Error: Table `stressor_responses` does not exist in the database.")
   }
-  
+
   data <- dbReadTable(db, "stressor_responses")
-  
+
   filtered_data <- filter_data_server(input, data, session)
-  
+
   progressive_data <- reactive({
     req(data)
     df <- data
-    
+
     if (!is.null(input$stressor) && length(input$stressor) > 0) {
       df <- df[df$stressor_name %in% input$stressor, ]
     }
@@ -152,10 +155,10 @@ server <- function(input, output, session) {
     if (!is.null(input$species_latin) && length(input$species_latin) > 0) {
       df <- df[df$species_latin %in% input$species_latin, ]
     }
-    
+
     df
   })
-  
+
   # pagination <- pagination_server(input, filtered_data)
   # paginated_data <- pagination$paginated_data
   # output$page_info <- renderText(pagination$page_info())
@@ -167,55 +170,119 @@ server <- function(input, output, session) {
   update_filters_server(input, output, session, data, db)
   toggle_filters_server(input, session)
   reset_filters_server(input, session)
-  
+
   upload_server("upload")
 
   edaServer("eda", db_path = "data/stressor_responses.sqlite")
-  
+
   render_papers_server(output, paginated_data, input, session)
-  
+
   # Download handler setup
   setup_download_csv(output, paginated_data, db, input)
 
-  
-
-  
   # Article display logic
+  # observe({
+  #   query <- parseQueryString(session$clientData$url_search)
+  #   if (!is.null(query$main_id)) {
+  #     main_id <- as.numeric(query$main_id)
+  #     if (!is.na(main_id)) {
+  #       tryCatch(
+  #         {
+  #           render_article_ui(output, session)
+  #           render_article_server(input, output, session, main_id, db)
+  #         },
+  #         error = function(e) {
+  #           output$article_content <- renderUI({
+  #             tags$p(paste("Error rendering article:", e$message), style = "color: red; font-weight: bold;")
+  #           })
+  #           print(e)
+  #         }
+  #       )
+  #     } else {
+  #       output$article_content <- renderUI(
+  #         tags$p("Article not found.", style = "color: red; font-weight: bold;")
+  #       )
+  #     }
+  #   }
+  # })
   observe({
-    query <- parseQueryString(session$clientData$url_search)
-    if (!is.null(query$main_id)) {
-      main_id <- as.numeric(query$main_id)
-      if (!is.na(main_id)) {
-        tryCatch({
-          render_article_ui(output, session)
-          render_article_server(input, output, session, main_id, db)
-        }, error = function(e) {
-          output$article_content <- renderUI({
-            tags$p(paste("Error rendering article:", e$message), style = "color: red; font-weight: bold;")
-          })
-          print(e)
-        })
-      } else {
-        output$article_content <- renderUI(
-          tags$p("Article not found.", style = "color: red; font-weight: bold;")
-        )
-      }
-    }
+    ids <- paginated_data()$main_id
+    lapply(ids, function(mid) {
+      observeEvent(input[[paste0("view_article_", mid)]],
+        {
+          showModal(modalDialog(
+            title = paste("Article", mid),
+            render_article_ui(mid, paginated_data()),
+            easyClose = TRUE,
+            size = "l"
+          ))
+          # This sets up all outputs for the selected article
+          render_article_server(input, output, session, mid, db)
+        },
+        ignoreInit = TRUE
+      )
+
+      observeEvent(input[[paste0("expand_all_", mid)]],
+        {
+          shinyjs::show("metadata_section")
+          shinyjs::show("description_section")
+          shinyjs::show("citations_section")
+          shinyjs::show("images_section")
+          shinyjs::show("csv_section")
+          shinyjs::show("interactive_plot_section")
+        },
+        ignoreInit = TRUE
+      )
+
+      observeEvent(input[[paste0("collapse_all_", mid)]],
+        {
+          shinyjs::hide("metadata_section")
+          shinyjs::hide("description_section")
+          shinyjs::hide("citations_section")
+          shinyjs::hide("images_section")
+          shinyjs::hide("csv_section")
+          shinyjs::hide("interactive_plot_section")
+        },
+        ignoreInit = TRUE
+      )
+    })
   })
-  
+
   # Section toggles
-  observeEvent(input$toggle_metadata, { toggle("metadata_section") })
-  observeEvent(input$toggle_description, { toggle("description_section") })
-  observeEvent(input$toggle_citations, { toggle("citations_section") })
-  observeEvent(input$toggle_images, { toggle("images_section") })
-  observeEvent(input$toggle_csv, { toggle("csv_section") })
-  observeEvent(input$toggle_plot, { toggle("plot_section") })
-  observeEvent(input$generate_plot, { show("compare_plot") })
-  observeEvent(filtered_data(), { updateNumericInput(session, "page", value = 1) })
-  observeEvent(input$toggle_interactive_plot, { toggle("interactive_plot_section") })
-  observeEvent(input$prev_page, { updateNumericInput(session, "page", value = max(1, input$page - 1)) })
-  observeEvent(input$next_page, { updateNumericInput(session, "page", value = input$page + 1) })
-  
+  observeEvent(input$toggle_metadata, {
+    toggle("metadata_section")
+  })
+  observeEvent(input$toggle_description, {
+    toggle("description_section")
+  })
+  observeEvent(input$toggle_citations, {
+    toggle("citations_section")
+  })
+  observeEvent(input$toggle_images, {
+    toggle("images_section")
+  })
+  observeEvent(input$toggle_csv, {
+    toggle("csv_section")
+  })
+  observeEvent(input$toggle_plot, {
+    toggle("plot_section")
+  })
+  observeEvent(input$generate_plot, {
+    show("compare_plot")
+  })
+  observeEvent(filtered_data(), {
+    updateNumericInput(session, "page", value = 1)
+  })
+  observeEvent(input$toggle_interactive_plot, {
+    toggle("interactive_plot_section")
+  })
+  observeEvent(input$prev_page, {
+    updateNumericInput(session, "page", value = max(1, input$page - 1))
+  })
+  observeEvent(input$next_page, {
+    updateNumericInput(session, "page", value = input$page + 1)
+  })
+
   # Close DB connection on session end
   session$onSessionEnded(function() {
     dbDisconnect(db)

--- a/ui.R
+++ b/ui.R
@@ -19,7 +19,7 @@ ui <- navbarPage(
   id = "main_navbar",
   title = "Salmon Stressor-Response eLibrary",
   selected = "dashboard",
-  
+
   # Welcome Tab
   tabPanel(
     title = "Welcome",
@@ -49,9 +49,6 @@ ui <- navbarPage(
     });
   "))
       ),
-
-      
-      
       h1("Welcome to the Salmon Stressor-Response eLibrary"),
       tags$div(
         h2("About Us"),
@@ -63,16 +60,14 @@ ui <- navbarPage(
       )
     )
   ),
-  
-  # Dashboard Tab
 
+  # Dashboard Tab
   tabPanel("Analyze Data", edaUI("eda")),
   tabPanel(
     title = "SRF Dashboard",
     value = "dashboard",
     fluidPage(
       useShinyjs(),
-      
       conditionalPanel(
         condition = "!window.location.search.includes('main_id')",
         fluidRow(
@@ -88,88 +83,127 @@ ui <- navbarPage(
         conditionalPanel(
           condition = "input.toggle_filters % 2 == 1",
           fluidRow(
-            column(3, pickerInput("stressor", "Stressor Name", choices = list(), multiple = TRUE,
-                                  options = list('actions-box' = TRUE, 'live-search' = TRUE))),
-            column(3, pickerInput("stressor_metric", "Stressor Metric", choices = list(), multiple = TRUE,
-                                  options = list('actions-box' = TRUE, 'live-search' = TRUE))),
-            column(3, pickerInput("species", "Species Common Name", choices = list(), multiple = TRUE,
-                                  options = list('actions-box' = TRUE, 'live-search' = TRUE))),
-            column(3, pickerInput("geography", "Geography (Region)", choices = list(), multiple = TRUE,
-                                  options = list('actions-box' = TRUE, 'live-search' = TRUE)))
+            column(3, pickerInput("stressor", "Stressor Name",
+              choices = list(), multiple = TRUE,
+              options = list("actions-box" = TRUE, "live-search" = TRUE)
+            )),
+            column(3, pickerInput("stressor_metric", "Stressor Metric",
+              choices = list(), multiple = TRUE,
+              options = list("actions-box" = TRUE, "live-search" = TRUE)
+            )),
+            column(3, pickerInput("species", "Species Common Name",
+              choices = list(), multiple = TRUE,
+              options = list("actions-box" = TRUE, "live-search" = TRUE)
+            )),
+            column(3, pickerInput("geography", "Geography (Region)",
+              choices = list(), multiple = TRUE,
+              options = list("actions-box" = TRUE, "live-search" = TRUE)
+            ))
           ),
           fluidRow(
-            column(3, pickerInput("life_stage", "Life Stage", choices = life_stages, multiple = TRUE,
-                                  options = list('actions-box' = TRUE, 'live-search' = TRUE))),
-            column(3, pickerInput("activity", "Activity", choices = list(), multiple = TRUE,
-                                  options = list('actions-box' = TRUE, 'live-search' = TRUE))),
-            column(3, pickerInput("genus_latin", "Genus Latin", choices = list(), multiple = TRUE,
-                                  options = list('actions-box' = TRUE, 'live-search' = TRUE))),
-            column(3, pickerInput("species_latin", "Species Latin", choices = list(), multiple = TRUE,
-                                  options = list('actions-box' = TRUE, 'live-search' = TRUE)))
+            column(3, pickerInput("life_stage", "Life Stage",
+              choices = life_stages, multiple = TRUE,
+              options = list("actions-box" = TRUE, "live-search" = TRUE)
+            )),
+            column(3, pickerInput("activity", "Activity",
+              choices = list(), multiple = TRUE,
+              options = list("actions-box" = TRUE, "live-search" = TRUE)
+            )),
+            column(3, pickerInput("genus_latin", "Genus Latin",
+              choices = list(), multiple = TRUE,
+              options = list("actions-box" = TRUE, "live-search" = TRUE)
+            )),
+            column(3, pickerInput("species_latin", "Species Latin",
+              choices = list(), multiple = TRUE,
+              options = list("actions-box" = TRUE, "live-search" = TRUE)
+            ))
           ),
           fluidRow(
-            column(3, pickerInput("research_article_type", "Research Article Type", choices = list(), multiple = TRUE,
-                                  options = list('actions-box' = TRUE, 'live-search' = TRUE))),
-            column(3, pickerInput("location_country", "Country", choices = list(), multiple = TRUE,
-                                  options = list('actions-box' = TRUE, 'live-search' = TRUE))),
-            column(3, pickerInput("location_state_province", "State / Province", choices = list(), multiple = TRUE,
-                                  options = list('actions-box' = TRUE, 'live-search' = TRUE))),
-            column(3, pickerInput("location_watershed_lab", "Watershed / Lab", choices = list(), multiple = TRUE,
-                                  options = list('actions-box' = TRUE, 'live-search' = TRUE)))
+            column(3, pickerInput("research_article_type", "Research Article Type",
+              choices = list(), multiple = TRUE,
+              options = list("actions-box" = TRUE, "live-search" = TRUE)
+            )),
+            column(3, pickerInput("location_country", "Country",
+              choices = list(), multiple = TRUE,
+              options = list("actions-box" = TRUE, "live-search" = TRUE)
+            )),
+            column(3, pickerInput("location_state_province", "State / Province",
+              choices = list(), multiple = TRUE,
+              options = list("actions-box" = TRUE, "live-search" = TRUE)
+            )),
+            column(3, pickerInput("location_watershed_lab", "Watershed / Lab",
+              choices = list(), multiple = TRUE,
+              options = list("actions-box" = TRUE, "live-search" = TRUE)
+            ))
           ),
           fluidRow(
-            column(3, pickerInput("location_river_creek", "River / Creek", choices = list(), multiple = TRUE,
-                                  options = list('actions-box' = TRUE, 'live-search' = TRUE))),
-            column(3, pickerInput("broad_stressor_name", "Broad Stressor Name", choices = list(), multiple = TRUE,
-                                  options = list('actions-box' = TRUE, 'live-search' = TRUE)))
+            column(3, pickerInput("location_river_creek", "River / Creek",
+              choices = list(), multiple = TRUE,
+              options = list("actions-box" = TRUE, "live-search" = TRUE)
+            )),
+            column(3, pickerInput("broad_stressor_name", "Broad Stressor Name",
+              choices = list(), multiple = TRUE,
+              options = list("actions-box" = TRUE, "live-search" = TRUE)
+            ))
           ),
           fluidRow(
-            column(12, div(style = "text-align: right;",
-                           actionLink("reset_filters", "Reset Filters",
-                                      style = "color: #0073e6; font-size: 14px; text-decoration: none; margin-right: 10px;")))
+            column(12, div(
+              style = "text-align: right;",
+              actionLink("reset_filters", "Reset Filters",
+                style = "color: #0073e6; font-size: 14px; text-decoration: none; margin-right: 10px;"
+              )
+            ))
           )
         ),
         fluidRow(
-          column(12,
-                div(style = "text-align: center; margin-bottom: 10px;",
-                    actionButton("prev_page", "<< Previous", class = "btn btn-sm"),
-                    span(textOutput("page_info", inline = TRUE), style = "margin: 0 10px; font-size: 13px;"),
-                    actionButton("next_page", "Next >>", class = "btn btn-sm")
-                )
+          column(
+            12,
+            div(
+              style = "text-align: center; margin-bottom: 10px;",
+              actionButton("prev_page", "<< Previous", class = "btn btn-sm"),
+              span(textOutput("page_info", inline = TRUE), style = "margin: 0 10px; font-size: 13px;"),
+              actionButton("next_page", "Next >>", class = "btn btn-sm")
+            )
           )
         ),
-
         dropdownButton(
           circle = FALSE,
           status = "primary",
           label = "Download",
           icon = icon("download"),
           tooltip = tooltipOptions(title = "Choose what to download"),
-          
+
           # Download type selector
-          radioButtons("download_option", label = NULL,
-                       choices = c("All Records" = "all", 
-                                   "Filtered Records" = "filtered", 
-                                   "Selected Records" = "selected"),
-                       selected = "all"),
-          
+          radioButtons("download_option",
+            label = NULL,
+            choices = c(
+              "All Records" = "all",
+              "Filtered Records" = "filtered",
+              "Selected Records" = "selected"
+            ),
+            selected = "all"
+          ),
+
           # Wrapped Confirm Download button with proper styling
-          div(style = "width: 100%;",
-              downloadButton("download_csv", "Confirm Download", class = "btn btn-success text-white btn-block"))
+          div(
+            style = "width: 100%;",
+            downloadButton("download_csv", "Confirm Download", class = "btn btn-success text-white btn-block")
+          )
         ),
-        
-        
+
+        # component for displaying the papers, displays all papers if no filters are applied
         fluidRow(
           column(6, offset = 3, uiOutput("paper_cards"))
         ),
         br(), br(),
-
         fluidRow(
-          column(12, align = "center",
+          column(12,
+            align = "center",
             actionButton("load_more_mode", "Load More", icon = icon("plus")),
             tags$br(), tags$br()
           )
         ),
+
         # Back to Top floating button
         tags$div(
           id = "back_to_top_fab",
@@ -191,25 +225,24 @@ ui <- navbarPage(
             $('html, body').animate({ scrollTop: 0 }, 'smooth');
           });
         "))
-
       ),
-      
-      conditionalPanel(
-        condition = "window.location.search.includes('main_id')",
-        fluidRow(
-          column(8, offset = 2, uiOutput("article_content"))
-        )
-      )
+
+      # conditionalPanel(
+      #   condition = "window.location.search.includes('main_id')",
+      #   fluidRow(
+      #     column(8, offset = 2, uiOutput("article_content"))
+      #   )
+      # )
     )
   ),
-  
+
   # Upload Tab
   tabPanel(
     title = "Upload Data",
     value = "upload_data",
     upload_ui("upload")
   ),
-  
+
   # Admin Tab
   tabPanel(
     title = "Admin",


### PR DESCRIPTION
fixes #3 
fixes #4

### Summary
- Article details now display in a modal popup, not a separate page.
- Filter choices and dashboard UI are preserved when viewing articles.
- Added working expand/collapse logic for all and individual sections in the article modal.
- Removed all `conditionalPanel` and URL-based logic for article viewing.

### Details
- In `ui.R`:
  - Removed all `conditionalPanel` and URL logic for article viewing (`main_id` references).
  - Dashboard and filters are always visible; article details are no longer rendered as a separate page.
  - Article list (`uiOutput("paper_cards")`) remains in the dashboard tab.
- In `render_papers.R`:
  - Changed article title links to `actionButton("view_article_<main_id>")` for each paper card.
  - This enables triggering the modal popup for article details.
- In `render_article_ui.R`:
  - Refactored to return a UI for the modal dialog, not assign to `output`.
  - Replaced expand/collapse all buttons and individual section toggles (metadata, description, citations, etc.) with `actionButton`/`actionLink`.
  - Used `shinyjs::hidden()` for initially hidden sections.
- In `server.R`:
  - Removed all observers and logic that used URL query (`main_id`) for article display.
  - Added observers for each article’s `view_article_<main_id>` button to show a modal with details using `render_article_ui`.
  - Called `render_article_server` inside the modal observer to set up outputs for the selected article.
  - Added observers for expand/collapse all buttons and individual section toggles, using unique IDs for each article modal.
  - Ensured filter state is preserved, and dashboard UI is not reset when viewing articles.